### PR TITLE
Use hex_repo.erl to download package tarball

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,5 @@
 {erl_opts, [debug_info]}.
 {project_plugins, [rebar3_hex]}.
+{deps,[
+    {hex_erl, {git, "https://github.com/hexpm/hex_erl.git", {branch, "master"}}}
+]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {erl_opts, [debug_info]}.
 {project_plugins, [rebar3_hex]}.
 {deps,[
-    {hex_erl, {git, "https://github.com/hexpm/hex_erl.git", {branch, "master"}}}
+    hex_core
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,0 +1,4 @@
+[{<<"hex_erl">>,
+  {git,"https://github.com/hexpm/hex_erl.git",
+       {ref,"ca37bcdd24268e9433d44fb797e2cc8d16269c2b"}},
+  0}].

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,6 @@
 {"1.1.0",
-[{<<"hex_core">>,{pkg,<<"hex_core">>,<<"0.2.0">>},0}]}.
+[{<<"hex_core">>,{pkg,<<"hex_core">>,<<"0.2.1">>},0}]}.
 [
 {pkg_hash,[
- {<<"hex_core">>, <<"3A7EACCFB8ADD3FF05D950C10ED5BDB5D0C48C988EBBC5D7AE2A55498F0EFF1B">>}]}
+ {<<"hex_core">>, <<"AC4A05DF753A728866A5BC0A11CB9719684C2DCD1837CE96392061B01CC69258">>}]}
 ].

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,6 @@
-[{<<"hex_erl">>,
-  {git,"https://github.com/hexpm/hex_erl.git",
-       {ref,"ca37bcdd24268e9433d44fb797e2cc8d16269c2b"}},
-  0}].
+{"1.1.0",
+[{<<"hex_core">>,{pkg,<<"hex_core">>,<<"0.2.0">>},0}]}.
+[
+{pkg_hash,[
+ {<<"hex_core">>, <<"3A7EACCFB8ADD3FF05D950C10ED5BDB5D0C48C988EBBC5D7AE2A55498F0EFF1B">>}]}
+].

--- a/src/rebar3_elixir_compile.app.src
+++ b/src/rebar3_elixir_compile.app.src
@@ -6,7 +6,8 @@
    [kernel,
     stdlib,
     crypto,
-    elixir
+    elixir,
+    hex_core
    ]},
   {env,[]},
   {modules, []},

--- a/src/rebar3_elixir_compile_resource.erl
+++ b/src/rebar3_elixir_compile_resource.erl
@@ -82,7 +82,7 @@ fetch({elixir, Name_, Vsn_}, CDN) ->
             Config = #{
               http_adapter => hex_http_httpc,
               http_adapter_config => #{profile => default},
-              http_user_agent_fragment => <<"(httpc)">>,
+              http_user_agent_fragment => user_agent(),
               repo_url => list_to_binary(CDN)
             },
             case hex_repo:get_tarball(Config, Name, Vsn) of
@@ -100,3 +100,13 @@ extract(Binary) ->
     {ok, Files} = erl_tar:extract({binary, Binary}, [memory]),
     {"contents.tar.gz", Contents} = lists:keyfind("contents.tar.gz", 1, Files),
     {ok, Contents}.
+
+user_agent() ->
+    AppName = rebar3_elixir_compile,
+    AppVsn = case lists:keyfind(AppName, 1, application:loaded_applications()) of
+                 {_, _, Ver} ->
+                     Ver;
+                 false ->
+                     "unknown"
+             end,
+    list_to_binary([atom_to_list(AppName), "/", AppVsn, " (httpc)"]).

--- a/src/rebar3_elixir_compile_resource.erl
+++ b/src/rebar3_elixir_compile_resource.erl
@@ -79,7 +79,13 @@ fetch({elixir, Name_, Vsn_}, CDN) ->
     Vsn  = rebar3_elixir_compile_util:to_binary(Vsn_),
     case filelib:is_dir(Dir) of
         false ->
-            case hex_repo:get_tarball(Name, Vsn, [{repo, #{uri => list_to_binary(CDN)}}]) of
+            Config = #{
+              http_adapter => hex_http_httpc,
+              http_adapter_config => #{profile => default},
+              http_user_agent_fragment => <<"(httpc)">>,
+              repo_url => list_to_binary(CDN)
+            },
+            case hex_repo:get_tarball(Config, Name, Vsn) of
                 {ok, Binary, _} ->
                     {ok, Contents} = extract(Binary),
                     ok = erl_tar:extract({binary, Contents}, [{cwd, Dir}, compressed]);


### PR DESCRIPTION
It would be good to use official hex.pm client to download package tarball.